### PR TITLE
Allow CMake to find freetype/freetype.h and ft2build.h

### DIFF
--- a/cmake/FindFreeType.cmake
+++ b/cmake/FindFreeType.cmake
@@ -2,11 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 find_path(FreeType_INCLUDE_DIR
-    NAMES ft2build.h
-    PATH_SUFFIXES freetype2
+    NAMES freetype.h
+    PATH_SUFFIXES freetype2/freetype
     HINTS $ENV{FREETYPE_ROOT}/include /usr/local/include)
 
-# need to find <freetype2/ft2build.h.h>
+# need to find <freetype2/ft2build.h>
 set(FreeType_INCLUDE_DIRS ${FreeType_INCLUDE_DIR} ${FreeType_INCLUDE_DIR}/..)
 
 find_library(FreeType_LIBRARIES


### PR DESCRIPTION
# ReleaseNote
## Compatibility (major, minor, patch, build)
build

## Jira ticket
None

## Release Notes Comment:  

When building with freetype2 installed via the MacOS `build-deps` build dependencies, CMake finds `freetype2/ft2build.h` in the `installs/include` folder, but does not know where to look for `freetype2/freetype/freetype.h`. As such, we need to find this header's folder as an include dir, and then also add the parent `freetype2` folder as an include dir. From the comment in the file, it seems like this is what was intended, but is not currently how `FindFreeType.cmake` is set up.

##Look or Scene Setup Change
No

# Reviewers
@jlanz 

# Pull request comments
When building with freetype2 installed through the MacOS openmoonray build-deps, CMake finds `freetype2/ft2build.h` in the `installs/include` folder, but does not know where to look for `freetype2/freetype/freetype.h`. As such, we need to find this header, and then also add the `freetype2` folder as an include directory as well. From the comment in the file, it seems like this is what was intended, but is not currently how FindFreeType.cmake is set up.
