### PR TITLE
Add missing <cstdint> include in ClockDelta.h for GCC 15

### DIFF
--- a/lib/share/util/ClockDelta.h
+++ b/lib/share/util/ClockDelta.h
@@ -7,6 +7,7 @@
 
 #include <mcrt_dataio/share/sock/SockServerInet.h>
 
+#include <cstdint>
 #include <string>
 
 namespace mcrt_dataio {


### PR DESCRIPTION
## Summary

`ClockDelta.h` uses `uint64_t` in the declaration of `analyzeRoundTripTimeDelta()` (lines 60–62) but does not include `<cstdint>`. This previously compiled because older libstdc++ leaked the definition transitively via other standard headers. GCC 15 / newer libstdc++ no longer does, so the build fails with:

```
moonray/moonray_arras/mcrt_dataio/lib/share/util/ClockDelta.h:60:44: error: 'uint64_t' has not been declared
moonray/moonray_arras/mcrt_dataio/lib/share/util/ClockDelta.h:61:44: error: 'uint64_t' has not been declared
moonray/moonray_arras/mcrt_dataio/lib/share/util/ClockDelta.h:62:44: error: 'uint64_t' has not been declared
moonray/moonray_arras/mcrt_dataio/lib/share/util/ClockDelta.cc:125:1: error: no declaration matches 'float mcrt_dataio::ClockDelta::analyzeRoundTripTimeDelta(uint64_t, uint64_t, uint64_t, float&)'
```

## Fix

Add `#include <cstdint>` to `ClockDelta.h`. This is the canonically correct header for the fixed-width integer typedefs and makes the header self-contained.

## Testing

Before this change, on GCC 15 (e.g. Arch Linux, Fedora 41+):
```sh
echo '#include "ClockDelta.h"' > /tmp/t.cc
g++-15 -std=c++17 -fsyntax-only -I<paths> /tmp/t.cc
# -> error: 'uint64_t' has not been declared (lines 60–62)
```
After this change, the header compiles cleanly and the full OpenMoonRay build progresses past `mcrt_dataio` on GCC 15.

## Related

Fixes OpenMoonRay/openmoonray#230

The header builds fine on the toolchains DreamWorks ships (older libstdc++) because they happen to leak `<cstdint>` transitively; this change is a strict tightening that does not affect those builds.